### PR TITLE
fix variable name in _renderSelect() method

### DIFF
--- a/src/FormService.php
+++ b/src/FormService.php
@@ -368,9 +368,9 @@ class FormService {
         $attrs = $this->_pts();
         $value = $this->_getValue();
         $options = '';
-        foreach ($this->_props['options'] as $value => $label){
-            $checked = $value == $value ? ' selected' : '';
-            $options .= '<option value="'.$value.'"'.$checked.'>'.$label.'</option>';
+        foreach ($this->_props['options'] as $optvalue => $label){
+            $checked = $optvalue == $value ? ' selected' : '';
+            $options .= '<option value="'.$optvalue.'"'.$checked.'>'.$label.'</option>';
         }
         return $this->_renderWarpperCommomField('<select '.$attrs.'>'.$options.'</select>');
     }


### PR DESCRIPTION
**Problem**
Addresses #3 

When using `Form::select()`, the current code includes a check for an existing value (from existing data) in line 369 of `FormService.php`. When it does this, it assigns such a value to a variable named `$value`, which is consistent with other methods in the application.

However, when parsing the `$options` array for the provided items to be converted to `<option>` elements, the `foreach` loop assigns each key to `$value`, which overwrites our existing value check.

Then, in line 372, we compare `$value == $value` to determine whether `selected` should be added to the HTML as an attribute on the `<option>` tag... and each time it will eval to `true` with the current logic.

**Solution**
I believe this to be a simple bug / oversight, and to fix it I propose renaming the key value in the `foreach()`loop to something different, like `$optvalue` (for 'option value'). Therefore the check in line 372 will correctly compare the key of the current option array against any existing value, therefore properly assigning the `selected` attribute only where a match is found.