### PR TITLE
Use custom attributes correctly.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -718,7 +718,7 @@ class FormBuilder {
             unset($props['class']);
         }
 
-        $allProps = array_merge($this->_attrs, $props);
+        $allProps = array_merge($props, $this->_attrs);
         foreach ($allProps as $key => $value) {
             if ($value === null) {
                 continue;


### PR DESCRIPTION
Custom attributes are ignored if they have a default value in the FormBuilder.
For example Form::textarea has a default of 3 rows defined in the FormBuilder.  You could not overrule that with custom attributes.
{!!Form::textarea('name', 'Name')->attrs(['rows' => 10])!!}  would still give you a textarea with 3 rows.  