### PR TITLE
Regression: Use custom attributes correctly.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -649,9 +649,10 @@ class FormBuilder {
      */
     private function _buildAttrs(array $props = [], array $ignore = []): string
     {
-        $props = array_merge(array_filter($this->_attrs, function($k){
-            return $k != 'class';
-        }, ARRAY_FILTER_USE_KEY), $props);
+        $props = array_merge($props,
+                             array_filter($this->_attrs, function($k){
+                                          return $k != 'class';
+                                         }, ARRAY_FILTER_USE_KEY));
 
         if($this->_type){
             $props['type'] = $this->_type;


### PR DESCRIPTION
Following code will give a textarea of 3 rows instead of 30.
{!! Form::textarea('comment', 'Comment')->attrs(['rows'=>30]) !!}
