### PR TITLE
Added support for horizontal forms and optional wrappers

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1010,8 +1010,6 @@ class FormBuilder {
 	        $formGroupClose = '</div>';
         }
 
-	    $this->_resetFlags();
-
 	    $inputGroupOpen = $inputGroupClose = '';
 
 	    if ($this->_wrapper && $this->_FformStyle === 'horizontal') {
@@ -1024,7 +1022,9 @@ class FormBuilder {
             $inputGroupClose .= '</div>';
         }
 
-        return $formGroupOpen . $label . $inputGroupOpen . $prefix . $field . $suffix . $inputGroupClose . $help . $error . $formGroupClose;
+	    $this->_resetFlags();
+
+	    return $formGroupOpen . $label . $inputGroupOpen . $prefix . $field . $suffix . $inputGroupClose . $help . $error . $formGroupClose;
     }
 
     /**

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1000,7 +1000,7 @@ class FormBuilder {
 	        $classList = isset($this->_wrapperAttrs['class']) ? $this->_wrapperAttrs['class'] : '';
 	        $this->_wrapperAttrs['class'] = "form-group " . $classList;
 
-	        if ($this->_FformStyle === 'horizontal') {
+	        if ($this->_FformStyle === 'horizontal'  && !$hide_label) {
 		        $this->_wrapperAttrs['class'] .= ' row';
 	        }
 
@@ -1012,7 +1012,7 @@ class FormBuilder {
 
 	    $inputGroupOpen = $inputGroupClose = '';
 
-	    if ($this->_wrapper && $this->_FformStyle === 'horizontal') {
+	    if ($this->_wrapper && $this->_FformStyle === 'horizontal' && !$hide_label) {
 		    $inputGroupOpen .= '<div class="col-sm-10">';
 		    $inputGroupClose .= '</div>';
 	    }

--- a/src/FormService.php
+++ b/src/FormService.php
@@ -198,7 +198,34 @@ class FormService {
      */
     public function inlineForm(bool $inline = true): FormService
     {
-        return $this->_set('FinlineForm', $inline);
+    	if($inline) {
+		    return $this->_set('FformStyle', 'inline');
+	    }else{
+    		return $this;
+	    }
+    }
+
+	/**
+	 * @param bool $wrapper
+	 * @return FormService
+	 */
+	public function noWrapper(bool $wrapper = false)
+    {
+	    return $this->_set('wrapper', $wrapper);
+    }
+
+	/**
+	 * Set horizontal form
+	 * @param bool $horizontal
+	 * @return FormService
+	 */
+	public function horizontalForm(bool $horizontal = true): FormService
+    {
+	    if($horizontal) {
+		    return $this->_set('FformStyle', 'horizontal');
+	    }else{
+		    return $this;
+	    }
     }
 
     /**


### PR DESCRIPTION
Refactored to include wrappers around checkboxes, radios, and buttons for horizontal support, so I added a noWrapper() method to make wrappers optional for any given input. Other than that, it's backwards compatible. 