### PR TITLE
Add field name array bracket support

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -1041,7 +1041,7 @@ class FormBuilder {
         if (!$errors) {
             return null;
         }
-        $error = $errors->first($this->_name);
+        $error = $errors->first($this->_transformToDotSyntax($this->_name));
 
         if (!$error) {
             return null;
@@ -1097,6 +1097,14 @@ class FormBuilder {
         $this->_Fdata = null;
         $this->_FidPrefix = '';
         $this->_Fautocomplete = null;
+    }
+
+    /**
+     * Convert to validator dot syntax
+     */
+    private function _transformToDotSyntax($string)
+    {
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $string);
     }
 
 }

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -804,7 +804,7 @@ class FormBuilder {
         $name = $this->_name;
 
         if ($this->_hasOldInput()) {
-            return old($name);
+            return old($this->_transformToDotSyntax($name));
         }
 
         if ($this->_value !== null) {


### PR DESCRIPTION
I ran into a similar issue as #46 where I needed to validate forms that use nested array bracket (`[]` ) names. 

Example form and request validator rules.
```html
<input type="text" name="author[name]"/>
<input type="text" name="author[description]"/>
```

```php
$request->validate([
    'author.name' => 'required',
    'author.description' => 'required',
]);
 ```
Instead of validating them correctly (or not finding the error at all), the package was throwing an exception.

This PR just adds a method that conditionally transforms the field names to a dot format (`'author[name]'` => `'author.name'` ) for the purpose of finding any applicable validation messages in the session's error message bag, as well as, find any old input values. This field names are transformd to match what Laravel's validators return for nested parameters  ([dot notation](https://laravel.com/docs/5.8/validation#validating-arrays)).

You'll notice the added `_transformToDotSyntax` also replaces other characters, namely `.` to `_` as that's how [PHP converts them](https://www.php.net/manual/en/language.variables.external.php) by default.