### PR TITLE
Button type was missing. (submit/reset button were ok)

### DIFF
--- a/src/FormService.php
+++ b/src/FormService.php
@@ -486,7 +486,7 @@ class FormService
      */
     public function button(string $value = null, $color = 'primary', $size = null): FormService
     {
-        return $this->_set('render', 'button')->value($value)->color($color)->size($size);
+        return $this->type('button')->set('render', 'button')->value($value)->color($color)->size($size);
     }
 
     /**
@@ -499,7 +499,7 @@ class FormService
      */
     public function submit(string $value, $color = 'primary', $size = null): FormService
     {
-        return $this->type('submit')->button($value, $color, $size);
+        return $this->button($value, $color, $size)->type('submit');
     }
 
     /**
@@ -512,7 +512,7 @@ class FormService
      */
     public function reset(string $value, $color = 'primary', $size = null): FormService
     {
-        return $this->type('reset')->button($value, $color, $size);
+        return $this->button($value, $color, $size)->type('reset');
     }
 
     /**


### PR DESCRIPTION
Regular button did not have a type. Causing a form submit instead of following the link when the button is inside a link.

Generated html before this patch:
`<a href="{link}">
<button class="btn btn-primary">Back</button>
</a>`


Instead of :
`<a href="{link}">
<button type="button" class="btn btn-primary">Back</button>
</a>`

-----
Laravel view code:

`{!! Form::submit('Delete')->danger() !!}        -> is ok`

`<a href="{{ $url }}">{!! Form::button('Back') !!}</a>    -> was wrong`