### PR TITLE
Effect placeholder in select.

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -147,7 +147,7 @@ class FormBuilder
         $optionsList = '';
         foreach ($options as $value => $label) {
             $attrs = $this->buildHtmlAttrs(['value' => $value, 'selected' => in_array($value, $arrValues)], false);
-            $optionsList .= '<option ' . $attrs . '>' . $label . '</option>';
+            $optionsList .= '<option ' . $attrs . ($value ?:' disabled hidden') . '>' . $label . '</option>';
         }
 
         $attributes = $this->getInputAttributes();

--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -147,7 +147,7 @@ class FormBuilder
         $optionsList = '';
         foreach ($options as $value => $label) {
             $attrs = $this->buildHtmlAttrs(['value' => $value, 'selected' => in_array($value, $arrValues)], false);
-            $optionsList .= '<option ' . $attrs . ($value ?:' disabled hidden') . '>' . $label . '</option>';
+            $optionsList .= '<option ' . $attrs . ($value ? '>' : ' disabled hidden>') . $label . '</option>';
         }
 
         $attributes = $this->getInputAttributes();


### PR DESCRIPTION
**Code executed [(forms->select->option)](https://github.com/netojose/laravel-bootstrap-4-forms#options):**
{!!Form::select('city', 'Choose your city')->options($cities->prepend('Choose your city', ''))!!}

**Problem:**
First option with empty value appears in the list and is selectable.

**Solution:**
Add attributes "disabled" and "hidden" to the option with empty value.

**Effect of new code:**
If the first select option has an empty string as its value, this will not appear in the list but will give the effect of the attribute "placeholder".

![Placeholder](https://user-images.githubusercontent.com/15143699/73801768-20828780-4781-11ea-8175-6aa43d9770e6.png)
