### PR TITLE
Fix multidimensional form validation

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -239,7 +239,7 @@ class FormBuilder
         $id = $this->getId();
 
         if (!$disableValidation && $this->errors()->count() > 0) {
-            $class .= $this->errors()->has($name) ? ' is-invalid' : ' is-valid';
+            $class .= $this->errors()->has(\rtrim(\str_replace(['[', ']'], '.', $name), '.')) ? ' is-invalid' : ' is-valid';
         }
 
         $attributes = [


### PR DESCRIPTION
I often use multidimensional forms with input name like **"name[of][the][variable]"** that cannot be properly validated.

This patch will resolve the issue.