### PR TITLE
Update FormBuilder.php

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -146,7 +146,7 @@ class FormBuilder
         $arrValues = is_array($fieldValue) ? $fieldValue : [$fieldValue];
         $optionsList = '';
         foreach ($options as $value => $label) {
-            $attrs = $this->buildHtmlAttrs(['value' => $value, 'selected' => in_array($value, $arrValues)], false);
+            $attrs = $this->buildHtmlAttrs(['value' => $value, 'selected' => in_array(strval($value), $arrValues)], false);
             $optionsList .= '<option ' . $attrs . '>' . $label . '</option>';
         }
 


### PR DESCRIPTION
fix options have 0 and null or empty
in_array(0, [null])
in_array(0, [''])
in_array(0, ['0'])
they are true

in_array('0', ['0']) => true
in_array('0', [null]) => false
in_array('0', ['']) => false