### PR TITLE
Added Laravel Dusk Element Shortcut

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -214,7 +214,7 @@ class FormBuilder
 
     private function getInputAttributes(): array
     {
-        extract($this->get('render', 'type', 'multiple', 'name', 'size', 'placeholder', 'help', 'disabled', 'readonly', 'required', 'autocomplete', 'min', 'max', 'value', 'checked', 'formData', 'disableValidation', 'custom'));
+        extract($this->get('render', 'type', 'multiple', 'name', 'size', 'placeholder', 'help', 'disabled', 'readonly', 'required', 'autocomplete', 'min', 'max', 'value', 'checked', 'formData', 'disableValidation', 'custom', 'dusk'));
 
         $isRadioOrCheckbox = $this->isRadioOrCheckbox();
         $type = $isRadioOrCheckbox ? $render : $type;
@@ -279,7 +279,8 @@ class FormBuilder
             'aria-describedby' => $help ? 'help-' . $id : null,
             'disabled' => $disabled,
             'readonly' => $readonly,
-            'required' => $required
+            'required' => $required,
+	    'dusk' => $dusk,
         ]);
     }
 

--- a/src/FormService.php
+++ b/src/FormService.php
@@ -826,6 +826,13 @@ class FormService
     {
         return $this->_set('attrs', $attrs);
     }
+	
+    /**
+     * Set dusk attribute for an input
+     */
+    public function dusk($duskAttribute): FormService {
+        return $this->_set('dusk', $duskAttribute);
+    }
 
     /**
      * Disable input states (valid and invalid classes) and error message


### PR DESCRIPTION
I really loved this package, but one of my concerns was when I create some Feature testing in Laravel I always forced to add custom attributes like this 

```php
Form::text('username', 'Username')->attrs(['dusk' => 'username'])
```

to generate an input like this
```html
<input dusk="username" name="username">
```

so I the shorthand i added some function to add dusk attribute into the input like this
```php
Form::text('username', 'Username')->dusk('username');
```