### PR TITLE
Update FormBuilder.php

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -522,11 +522,18 @@ class FormBuilder
 
     private function errors()
     {
-        $errors = session('errors', app(ViewErrorBag::class));
         extract($this->get('formErrorBag'));
-        if ($formErrorBag) {
-            $errors = $errors->{$formErrorBag};
+
+        if($formErrorBag instanceof \Illuminate\Support\MessageBag) {
+            $errors = $formErrorBag;    
         }
+        else {
+            $errors = session('errors', app(ViewErrorBag::class));
+                if ($formErrorBag) {
+                    $errors = $errors->{$formErrorBag};
+                }
+        }
+
         return $errors;
     }
 


### PR DESCRIPTION
Changed error() function to handle messageBag objects passed directly from blade or revert to default if no valid messageBag passed. This allows the form to be rendered directly in a controller with form errors, without the need for a redirect - useful for ajax requests.