### PR TITLE
Allow errorBag object to be passed to form as well as errorBag name

### DIFF
--- a/src/FormBuilder.php
+++ b/src/FormBuilder.php
@@ -522,11 +522,18 @@ class FormBuilder
 
     private function errors()
     {
-        $errors = session('errors', app(ViewErrorBag::class));
         extract($this->get('formErrorBag'));
-        if ($formErrorBag) {
-            $errors = $errors->{$formErrorBag};
+
+        if($formErrorBag instanceof \Illuminate\Support\MessageBag) {
+            $errors = $formErrorBag;    
         }
+        else {
+        	$errors = session('errors', app(ViewErrorBag::class));
+                if ($formErrorBag) {
+                    $errors = $errors->{$formErrorBag};
+                }
+        }
+
         return $errors;
     }
 

--- a/src/FormService.php
+++ b/src/FormService.php
@@ -29,13 +29,17 @@ class FormService
     }
 
     /**
-     * Set error bag name
+     * Set error bag name or provide errorBag object
      *
      * @param string $value
      * @return FormService
      */
-    public function errorBag(string $value = null): FormService
+    public function errorBag($value = null): FormService
     {
+        if (!is_string($value) && !$value instanceof \Illuminate\Support\MessageBag) {
+            throw new \InvalidArgumentException('$value must be a string or a MessageBag object.');
+        }
+
         return $this->_set('formErrorBag', $value);
     }
 


### PR DESCRIPTION
If the form is rendered to a string in a controller as part of an ajax request, the errorBag stored in the session isn't available unless a redirect is used. This proposed change will allow an errorBag object to be provided as well as a string reference.

**Controller:**
```
$validator = Validator::make (
    $request->all(), 
    ['id'   => 'required']                                       
);

$html = View::make('my-form')->with(['formData' => $formData, 'formErrors'=>$validator])->render();

return response()->json($html);  
```

**Form View:**
```
{!! Form::open()->post()->route('update')->id('my-form')->fill($formData)->errorBag($formErrors) !!}
    {!!Form::errors("The form has errors")!!}
    {!! Form::text('id', 'ID') !!}                               
    {!!Form::submit("Update")!!}
{!! Form::close() !!}
```